### PR TITLE
HUB-1835, updated login translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.0.2] - 2025-06-22
+
+* [GitHub release notes](https://github.com/peterlembke/infohub_translate/releases/tag/v1.0.2)
+
+Updated translation files for infohub_login to translate better into Swedish. Hope that helps other languages as well.
+
 # [1.0.1] - 2025-06-16
 
 * [GitHub release notes](https://github.com/peterlembke/infohub_translate/releases/tag/v1.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [GitHub release notes](https://github.com/peterlembke/infohub_translate/releases/tag/v1.0.1)
 
-Updated translation files for infohub_login, infohub_doc, charzam_calculate.
+Updated translation files for infohub_login, infohub_doc, charzam_calculate, infohub_launcher.
 
 # [1.0.0] - 2025-06-08
 

--- a/infohub_login/ar.json
+++ b/infohub_login/ar.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:29:29",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ar",
         "language_name": "Arabic",
         "language_name_local": "العربية",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "ملفات مختارة",
             "PASSWORD_KEY": "كلمة السر",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "حساب التحميل",
-            "LOGIN_RESULT_KEY": "النتيجة",
-            "MORE_KEY": "أكثر",
-            "CURRENT_URL_KEY": "الحالي",
-            "RELOAD_THE_PAGE_KEY": "Reload the page"
+            "RESULT_KEY": "النتيجة",
+            "SHOW_MORE_KEY": "أظهر المزيد",
+            "CURRENT_ADDRESS_KEY": "العنوان الحالي",
+            "UPDATE_THE_PAGE_KEY": "تحديث الصفحة"
         }
     }
 }

--- a/infohub_login/az.json
+++ b/infohub_login/az.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:29:34",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "az",
         "language_name": "Azerbaijani",
         "language_name_local": "Bakı",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Proqram",
             "PASSWORD_KEY": "Qeydiyyat",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Proqram hesabı",
-            "LOGIN_RESULT_KEY": "Daxil ol",
-            "MORE_KEY": "Daha çox",
-            "CURRENT_URL_KEY": "Daxil ol",
-            "RELOAD_THE_PAGE_KEY": " page"
+            "RESULT_KEY": "Sonuncu",
+            "SHOW_MORE_KEY": "Daha çox",
+            "CURRENT_ADDRESS_KEY": "Ad Soyad",
+            "UPDATE_THE_PAGE_KEY": " the"
         }
     }
 }

--- a/infohub_login/bg.json
+++ b/infohub_login/bg.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:38",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "bg",
         "language_name": "Bulgarian",
         "language_name_local": "Български",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Избор на файл",
             "PASSWORD_KEY": "Парола",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Изтегляне на демо сметка",
-            "LOGIN_RESULT_KEY": "Входящ резултат",
-            "MORE_KEY": "Още",
-            "CURRENT_URL_KEY": "Текущ URL",
-            "RELOAD_THE_PAGE_KEY": "Презареждане на страницата"
+            "RESULT_KEY": "Резултат",
+            "SHOW_MORE_KEY": "Показване на повече",
+            "CURRENT_ADDRESS_KEY": "Текущ адрес",
+            "UPDATE_THE_PAGE_KEY": "Обновяване на страницата"
         }
     }
 }

--- a/infohub_login/bn.json
+++ b/infohub_login/bn.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:31",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "bn",
         "language_name": "Bengali",
         "language_name_local": "বাংলা",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "ফাইল নির্বাচন করুন",
             "PASSWORD_KEY": "পাসওয়ার্ড",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "অ্যাকাউন্ট ডাউনলোড করো",
-            "LOGIN_RESULT_KEY": "লগ-ইন ফলাফল",
-            "MORE_KEY": "মডেল",
-            "CURRENT_URL_KEY": "বর্তমান url",
-            "RELOAD_THE_PAGE_KEY": "পৃষ্ঠা পুনরায় লোড করুন"
+            "RESULT_KEY": "ফলাফল",
+            "SHOW_MORE_KEY": "আরো বেশি দেখাও",
+            "CURRENT_ADDRESS_KEY": "বর্তমান ঠিকানা",
+            "UPDATE_THE_PAGE_KEY": "পেজ আপডেট করুন"
         }
     }
 }

--- a/infohub_login/ca.json
+++ b/infohub_login/ca.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:44",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ca",
         "language_name": "Catalan",
         "language_name_local": "CatalàName",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Selecció de fitxer",
             "PASSWORD_KEY": "Contrasenya",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Descarrega el compte de demostració",
-            "LOGIN_RESULT_KEY": "Resultat de l' entrada",
-            "MORE_KEY": "Més",
-            "CURRENT_URL_KEY": "URL actual",
-            "RELOAD_THE_PAGE_KEY": "Recarrega la pàgina"
+            "RESULT_KEY": "Resultat",
+            "SHOW_MORE_KEY": "Mostra més",
+            "CURRENT_ADDRESS_KEY": "Adreça actual",
+            "UPDATE_THE_PAGE_KEY": "Actualitza la pàgina"
         }
     }
 }

--- a/infohub_login/cs.json
+++ b/infohub_login/cs.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:52",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "cs",
         "language_name": "Czech",
         "language_name_local": "Česká republika",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Vybrat soubor",
             "PASSWORD_KEY": "Heslo",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Stáhnout demo účet",
-            "LOGIN_RESULT_KEY": "Výsledek přihlášení",
-            "MORE_KEY": "Více",
-            "CURRENT_URL_KEY": "Aktuální url",
-            "RELOAD_THE_PAGE_KEY": "Obnovit stránku"
+            "RESULT_KEY": "Výsledek",
+            "SHOW_MORE_KEY": "Zobrazit více",
+            "CURRENT_ADDRESS_KEY": "Současná adresa",
+            "UPDATE_THE_PAGE_KEY": "Aktualizovat stránku"
         }
     }
 }

--- a/infohub_login/da.json
+++ b/infohub_login/da.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:32:08",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "da",
         "language_name": "Danish",
         "language_name_local": "Dansk",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Vælg fil",
             "PASSWORD_KEY": "Adgangskode",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Download demo-konto",
-            "LOGIN_RESULT_KEY": "Login resultat",
-            "MORE_KEY": "Mere",
-            "CURRENT_URL_KEY": "Nuværende url",
-            "RELOAD_THE_PAGE_KEY": "Genindlæs siden"
+            "RESULT_KEY": "Resultat",
+            "SHOW_MORE_KEY": "Flere",
+            "CURRENT_ADDRESS_KEY": "Nuværende adresse",
+            "UPDATE_THE_PAGE_KEY": "Opdatér siden"
         }
     }
 }

--- a/infohub_login/de.json
+++ b/infohub_login/de.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "de",
         "language_name": "German",
         "language_name_local": "Deutsch",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Wählen Sie die Datei",
             "PASSWORD_KEY": "Passwort vergessen",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demo-Konto herunterladen",
-            "LOGIN_RESULT_KEY": "Anmeldeergebnis",
-            "MORE_KEY": "Mehr",
-            "CURRENT_URL_KEY": "Aktueller url",
-            "RELOAD_THE_PAGE_KEY": "Nachladen der Seite"
+            "RESULT_KEY": "Ergebnis",
+            "SHOW_MORE_KEY": "Mehr erfahren",
+            "CURRENT_ADDRESS_KEY": "Aktuelle Adresse",
+            "UPDATE_THE_PAGE_KEY": "Seite aktualisieren"
         }
     }
 }

--- a/infohub_login/el.json
+++ b/infohub_login/el.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "el",
         "language_name": "Greek",
         "language_name_local": "Ελληνικά",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Επιλογή αρχείου",
             "PASSWORD_KEY": "Κωδικός πρόσβασης",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Λήψη λογαριασμού επίδειξης",
-            "LOGIN_RESULT_KEY": "Αποτέλεσμα σύνδεσης",
-            "MORE_KEY": "Περισσότερα",
-            "CURRENT_URL_KEY": "Τρέχων url",
-            "RELOAD_THE_PAGE_KEY": "Επαναφόρτωση σελίδας"
+            "RESULT_KEY": "Αποτέλεσμα",
+            "SHOW_MORE_KEY": "Εμφάνιση περισσότερων",
+            "CURRENT_ADDRESS_KEY": "Τρέχουσα διεύθυνση",
+            "UPDATE_THE_PAGE_KEY": "Ενημέρωση της σελίδας"
         }
     }
 }

--- a/infohub_login/en.json
+++ b/infohub_login/en.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:16:30",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "en",
         "language_name": "English",
         "language_name_local": "English",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Select file",
             "PASSWORD_KEY": "Password",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Download demo account",
-            "LOGIN_RESULT_KEY": "Login result",
-            "MORE_KEY": "More",
-            "CURRENT_URL_KEY": "Current url",
-            "RELOAD_THE_PAGE_KEY": "Reload the page"
+            "RESULT_KEY": "Result",
+            "SHOW_MORE_KEY": "Show more",
+            "CURRENT_ADDRESS_KEY": "Current address",
+            "UPDATE_THE_PAGE_KEY": "Update the page"
         }
     }
 }

--- a/infohub_login/eo.json
+++ b/infohub_login/eo.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:32:08",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "eo",
         "language_name": "Esperanto",
         "language_name_local": "Esperanto",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Elektu dosieron",
             "PASSWORD_KEY": "Pasvorto",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demo konto",
-            "LOGIN_RESULT_KEY": "Login-rezulto",
-            "MORE_KEY": "Pli",
-            "CURRENT_URL_KEY": "Nuna url",
-            "RELOAD_THE_PAGE_KEY": "Reŝargu la paĝon"
+            "RESULT_KEY": "RESult",
+            "SHOW_MORE_KEY": "Montri pli",
+            "CURRENT_ADDRESS_KEY": "Nuna adreso",
+            "UPDATE_THE_PAGE_KEY": "Ĝisdatigu la paĝon"
         }
     }
 }

--- a/infohub_login/es.json
+++ b/infohub_login/es.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "es",
         "language_name": "Spanish",
         "language_name_local": "Español",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Seleccione el archivo",
             "PASSWORD_KEY": "Contraseña",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Descargar cuenta demo",
-            "LOGIN_RESULT_KEY": "Resultado de inicio",
-            "MORE_KEY": "Más",
-            "CURRENT_URL_KEY": "Url actual",
-            "RELOAD_THE_PAGE_KEY": "Recargar la página"
+            "RESULT_KEY": "Resultado",
+            "SHOW_MORE_KEY": "Mostrar más",
+            "CURRENT_ADDRESS_KEY": "Dirección actual",
+            "UPDATE_THE_PAGE_KEY": "Actualizar la página"
         }
     }
 }

--- a/infohub_login/et.json
+++ b/infohub_login/et.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "et",
         "language_name": "Estonian",
         "language_name_local": "Eesti",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Faili valimine",
             "PASSWORD_KEY": "Parool",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demokonto allalaadimine",
-            "LOGIN_RESULT_KEY": "Sisselogimise tulemus",
-            "MORE_KEY": "Rohkem",
-            "CURRENT_URL_KEY": "Praegune URL",
-            "RELOAD_THE_PAGE_KEY": "Laadi lehekülg uuesti"
+            "RESULT_KEY": "Tulemus",
+            "SHOW_MORE_KEY": "Näita rohkem",
+            "CURRENT_ADDRESS_KEY": "Aktiivne aadress",
+            "UPDATE_THE_PAGE_KEY": "Lehe uuendamine"
         }
     }
 }

--- a/infohub_login/eu.json
+++ b/infohub_login/eu.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:24",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "eu",
         "language_name": "Basque",
         "language_name_local": "Euskara",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Hautatu fitxategia",
             "PASSWORD_KEY": "Pasahitza",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Deskargatu demo kontua",
-            "LOGIN_RESULT_KEY": "Saio-hasierako emaitza",
-            "MORE_KEY": "Gehiago",
-            "CURRENT_URL_KEY": "Uneko url",
-            "RELOAD_THE_PAGE_KEY": "Birkargatu orrialdea"
+            "RESULT_KEY": "Emaitza",
+            "SHOW_MORE_KEY": "Erakutsi gehiago",
+            "CURRENT_ADDRESS_KEY": "Uneko helbidea",
+            "UPDATE_THE_PAGE_KEY": "Eguneratu orrialdea"
         }
     }
 }

--- a/infohub_login/fa.json
+++ b/infohub_login/fa.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "fa",
         "language_name": "Persian",
         "language_name_local": "فارسی",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "انتخاب فایل",
             "PASSWORD_KEY": "Password",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "دانلود بازی Demo account",
-            "LOGIN_RESULT_KEY": "نتیجه ورود",
-            "MORE_KEY": "بیشتر",
-            "CURRENT_URL_KEY": "URL فعلی",
-            "RELOAD_THE_PAGE_KEY": "بارگذاری صفحه"
+            "RESULT_KEY": "نتیجه",
+            "SHOW_MORE_KEY": "نمایش بیشتر",
+            "CURRENT_ADDRESS_KEY": "آدرس فعلی",
+            "UPDATE_THE_PAGE_KEY": "به روز رسانی صفحه"
         }
     }
 }

--- a/infohub_login/fi.json
+++ b/infohub_login/fi.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "fi",
         "language_name": "Finnish",
         "language_name_local": "Suomi",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Valitse tiedosto",
             "PASSWORD_KEY": "Salasana",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Lataa demotili",
-            "LOGIN_RESULT_KEY": "Kirjautumistulos",
-            "MORE_KEY": "Lisää",
-            "CURRENT_URL_KEY": "Nykyinen uRL",
-            "RELOAD_THE_PAGE_KEY": "Lataa sivu uudelleen"
+            "RESULT_KEY": "Tulos",
+            "SHOW_MORE_KEY": "Näytä lisää",
+            "CURRENT_ADDRESS_KEY": "Nykyinen osoite",
+            "UPDATE_THE_PAGE_KEY": "Päivitä sivu"
         }
     }
 }

--- a/infohub_login/fr.json
+++ b/infohub_login/fr.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "fr",
         "language_name": "French",
         "language_name_local": "Français",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Sélectionner un fichier",
             "PASSWORD_KEY": "Mot de passe",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Télécharger le compte démo",
-            "LOGIN_RESULT_KEY": "Résultat de la connexion",
-            "MORE_KEY": "Plus",
-            "CURRENT_URL_KEY": "Durée actuelle",
-            "RELOAD_THE_PAGE_KEY": "Recharger la page"
+            "RESULT_KEY": "Résultat",
+            "SHOW_MORE_KEY": "Afficher plus",
+            "CURRENT_ADDRESS_KEY": "Adresse actuelle",
+            "UPDATE_THE_PAGE_KEY": "Mettre à jour la page"
         }
     }
 }

--- a/infohub_login/ga.json
+++ b/infohub_login/ga.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ga",
         "language_name": "Irish",
         "language_name_local": "Gaeilge na hÉireann",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Roghnaigh comhad",
             "PASSWORD_KEY": "Post a fhógairt",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Íoslódáil cuntas taispeána",
-            "LOGIN_RESULT_KEY": "Toradh Logáil isteach",
-            "MORE_KEY": "Tuilleadh eolais",
-            "CURRENT_URL_KEY": "Taiseachas aeir: fliuch",
-            "RELOAD_THE_PAGE_KEY": "Athlódáil an leathanach"
+            "RESULT_KEY": "Toradh agus Toradh",
+            "SHOW_MORE_KEY": "Taispeáin níos mó",
+            "CURRENT_ADDRESS_KEY": "Seoladh reatha",
+            "UPDATE_THE_PAGE_KEY": "Nuashonraigh an leathanach"
         }
     }
 }

--- a/infohub_login/gl.json
+++ b/infohub_login/gl.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "gl",
         "language_name": "Galician",
         "language_name_local": "Galego",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Seleccione ficheiro",
             "PASSWORD_KEY": "Contrasinal",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Baixar demo account",
-            "LOGIN_RESULT_KEY": "Resultados Login",
-            "MORE_KEY": "Máis",
-            "CURRENT_URL_KEY": "Url actual",
-            "RELOAD_THE_PAGE_KEY": "Recarga a páxina"
+            "RESULT_KEY": "Resultado",
+            "SHOW_MORE_KEY": "Mostrar máis",
+            "CURRENT_ADDRESS_KEY": "Enderezo actual",
+            "UPDATE_THE_PAGE_KEY": "Actualizar a páxina"
         }
     }
 }

--- a/infohub_login/he.json
+++ b/infohub_login/he.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "he",
         "language_name": "Hebrew",
         "language_name_local": "עברית",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "קובץ",
             "PASSWORD_KEY": "סיסמה",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "הורד חשבון ההדגמה",
-            "LOGIN_RESULT_KEY": "תוצאות",
-            "MORE_KEY": "עוד יותר",
-            "CURRENT_URL_KEY": "Url",
-            "RELOAD_THE_PAGE_KEY": "Reload the page"
+            "RESULT_KEY": "תוצאה",
+            "SHOW_MORE_KEY": "הצג עוד",
+            "CURRENT_ADDRESS_KEY": "הכתובת הנוכחית",
+            "UPDATE_THE_PAGE_KEY": "עדכון הדף"
         }
     }
 }

--- a/infohub_login/hi.json
+++ b/infohub_login/hi.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "hi",
         "language_name": "Hindi",
         "language_name_local": "हिन्दी",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "फ़ाइल चुनें",
             "PASSWORD_KEY": "पासवर्ड",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "डेमो खाता डाउनलोड करें",
-            "LOGIN_RESULT_KEY": "लॉग इन करें",
-            "MORE_KEY": "अधिक",
-            "CURRENT_URL_KEY": "वर्तमान यूआरएल",
-            "RELOAD_THE_PAGE_KEY": "पृष्ठ रीलोड करें"
+            "RESULT_KEY": "परिणाम",
+            "SHOW_MORE_KEY": "और देखो",
+            "CURRENT_ADDRESS_KEY": "वर्तमान पता",
+            "UPDATE_THE_PAGE_KEY": "पेज को अपडेट करें"
         }
     }
 }

--- a/infohub_login/hu.json
+++ b/infohub_login/hu.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "hu",
         "language_name": "Hungarian",
         "language_name_local": "Magyar",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Fájl kiválasztása",
             "PASSWORD_KEY": "Jelszó",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demo fiók letöltése",
-            "LOGIN_RESULT_KEY": "Bejelentkezési eredmény",
-            "MORE_KEY": "Több",
-            "CURRENT_URL_KEY": "Aktuális URl",
-            "RELOAD_THE_PAGE_KEY": "Az oldal újratöltése"
+            "RESULT_KEY": "Eredmény",
+            "SHOW_MORE_KEY": "Bővebben",
+            "CURRENT_ADDRESS_KEY": "Jelenlegi cím",
+            "UPDATE_THE_PAGE_KEY": "Az oldal frissítése"
         }
     }
 }

--- a/infohub_login/id.json
+++ b/infohub_login/id.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "id",
         "language_name": "Indonesian",
         "language_name_local": "Indonesia",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Pilih berkas",
             "PASSWORD_KEY": "Sandi",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Unduh akun demo",
-            "LOGIN_RESULT_KEY": "Hasil log masuk",
-            "MORE_KEY": "Lebih",
-            "CURRENT_URL_KEY": "Url saat ini",
-            "RELOAD_THE_PAGE_KEY": "Muat ulang halaman"
+            "RESULT_KEY": "Hasil",
+            "SHOW_MORE_KEY": "Tampilkan lebih banyak",
+            "CURRENT_ADDRESS_KEY": "Alamat saat ini",
+            "UPDATE_THE_PAGE_KEY": "Perbarui halaman"
         }
     }
 }

--- a/infohub_login/it.json
+++ b/infohub_login/it.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "it",
         "language_name": "Italian",
         "language_name_local": "Italiano",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Selezionare il file",
             "PASSWORD_KEY": "Password",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Scarica l'account demo",
-            "LOGIN_RESULT_KEY": "Risultato di login",
-            "MORE_KEY": "Altro",
-            "CURRENT_URL_KEY": "Url corrente",
-            "RELOAD_THE_PAGE_KEY": "Ricarica la pagina"
+            "RESULT_KEY": "Risultato",
+            "SHOW_MORE_KEY": "Mostra di più",
+            "CURRENT_ADDRESS_KEY": "Indirizzo attuale",
+            "UPDATE_THE_PAGE_KEY": "Aggiorna la pagina"
         }
     }
 }

--- a/infohub_login/ja.json
+++ b/infohub_login/ja.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ja",
         "language_name": "Japanese",
         "language_name_local": "日本語 English",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "ファイルの選択",
             "PASSWORD_KEY": "パスワード",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "デモ口座をダウンロード",
-            "LOGIN_RESULT_KEY": "ログイン結果",
-            "MORE_KEY": "ニュース",
-            "CURRENT_URL_KEY": "現在の URL",
-            "RELOAD_THE_PAGE_KEY": "ページのリロード"
+            "RESULT_KEY": "結果発表",
+            "SHOW_MORE_KEY": "もっと表示",
+            "CURRENT_ADDRESS_KEY": "現在のアドレス",
+            "UPDATE_THE_PAGE_KEY": "ページの更新"
         }
     }
 }

--- a/infohub_login/ko.json
+++ b/infohub_login/ko.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ko",
         "language_name": "Korean",
         "language_name_local": "한국어",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "파일 선택",
             "PASSWORD_KEY": "비밀번호",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "데모 계정 다운로드",
-            "LOGIN_RESULT_KEY": "로그인 결과",
-            "MORE_KEY": "더 보기",
-            "CURRENT_URL_KEY": "현재 URL",
-            "RELOAD_THE_PAGE_KEY": "자주 묻는 질문"
+            "RESULT_KEY": "제품정보",
+            "SHOW_MORE_KEY": "더 보기",
+            "CURRENT_ADDRESS_KEY": "현재 주소",
+            "UPDATE_THE_PAGE_KEY": "자주 묻는 질문"
         }
     }
 }

--- a/infohub_login/lt.json
+++ b/infohub_login/lt.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "lt",
         "language_name": "Lithuanian",
         "language_name_local": "Lietuvių",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Pasirinkite failą",
             "PASSWORD_KEY": "Slaptažodis",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Atsisiųsti demo paskyrą",
-            "LOGIN_RESULT_KEY": "Prisijungimo rezultatas",
-            "MORE_KEY": "Daugiau",
-            "CURRENT_URL_KEY": "Dabartinis URL",
-            "RELOAD_THE_PAGE_KEY": "Iš naujo įkelti puslapį"
+            "RESULT_KEY": "Rezultatas",
+            "SHOW_MORE_KEY": "Rodyti daugiau",
+            "CURRENT_ADDRESS_KEY": "Dabartinis adresas",
+            "UPDATE_THE_PAGE_KEY": "Atnaujinti puslapį"
         }
     }
 }

--- a/infohub_login/lv.json
+++ b/infohub_login/lv.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "lv",
         "language_name": "Latvian",
         "language_name_local": "Latviešu",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Izvēlieties failu",
             "PASSWORD_KEY": "Parole",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Lejupielādēt demo kontu",
-            "LOGIN_RESULT_KEY": "Pieteikšanās rezultāts",
-            "MORE_KEY": "Vairāk",
-            "CURRENT_URL_KEY": "Pašreizējais URL",
-            "RELOAD_THE_PAGE_KEY": "Pārielādēt lapu"
+            "RESULT_KEY": "Rezultāts",
+            "SHOW_MORE_KEY": "Rādīt vairāk",
+            "CURRENT_ADDRESS_KEY": "Pašreizējā adrese",
+            "UPDATE_THE_PAGE_KEY": "Atjaunināt lapu"
         }
     }
 }

--- a/infohub_login/ms.json
+++ b/infohub_login/ms.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ms",
         "language_name": "Malay",
         "language_name_local": "Bahasa Melayu",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Pilih berkas",
             "PASSWORD_KEY": "Kata Sandi",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Muat turun akun demo",
-            "LOGIN_RESULT_KEY": "Hasil Daftar Masuk",
-            "MORE_KEY": "Amerika Serikat",
-            "CURRENT_URL_KEY": "Url saat ini",
-            "RELOAD_THE_PAGE_KEY": "Kuncupkan semula halaman"
+            "RESULT_KEY": "Hasil",
+            "SHOW_MORE_KEY": "Lebih banyak pertunjukan",
+            "CURRENT_ADDRESS_KEY": "Alamat saat ini",
+            "UPDATE_THE_PAGE_KEY": "Update halaman"
         }
     }
 }

--- a/infohub_login/nb.json
+++ b/infohub_login/nb.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "nb",
         "language_name": "Norwegian",
         "language_name_local": "Norsk",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Velg fil",
             "PASSWORD_KEY": "Passord",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Last ned demokonto",
-            "LOGIN_RESULT_KEY": "Innloggingsresultat",
-            "MORE_KEY": "Mer",
-            "CURRENT_URL_KEY": "Nåværende URL",
-            "RELOAD_THE_PAGE_KEY": "Last siden på nytt"
+            "RESULT_KEY": "Resultat",
+            "SHOW_MORE_KEY": "Vis mer",
+            "CURRENT_ADDRESS_KEY": "Gjeldende adresse",
+            "UPDATE_THE_PAGE_KEY": "Oppdater siden"
         }
     }
 }

--- a/infohub_login/nl.json
+++ b/infohub_login/nl.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:32:08",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "nl",
         "language_name": "Dutch",
         "language_name_local": "Nederlands",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Bestand selecteren",
             "PASSWORD_KEY": "Wachtwoord",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demo-account downloaden",
-            "LOGIN_RESULT_KEY": "Aanmeldresultaat",
-            "MORE_KEY": "Meer",
-            "CURRENT_URL_KEY": "Huidige url",
-            "RELOAD_THE_PAGE_KEY": "Pagina herladen"
+            "RESULT_KEY": "Resultaat",
+            "SHOW_MORE_KEY": "Meer tonen",
+            "CURRENT_ADDRESS_KEY": "Huidig adres",
+            "UPDATE_THE_PAGE_KEY": "De pagina bijwerken"
         }
     }
 }

--- a/infohub_login/pl.json
+++ b/infohub_login/pl.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "pl",
         "language_name": "Polish",
         "language_name_local": "Polski",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Wybierz plik",
             "PASSWORD_KEY": "Hasło",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Pobierz konto demo",
-            "LOGIN_RESULT_KEY": "Wynik logowania",
-            "MORE_KEY": "Więcej",
-            "CURRENT_URL_KEY": "Bieżący url",
-            "RELOAD_THE_PAGE_KEY": "Wczytaj ponownie stronę"
+            "RESULT_KEY": "Wynik",
+            "SHOW_MORE_KEY": "Pokaż więcej",
+            "CURRENT_ADDRESS_KEY": "Aktualny adres",
+            "UPDATE_THE_PAGE_KEY": "Aktualizuj stronę"
         }
     }
 }

--- a/infohub_login/pt-BR.json
+++ b/infohub_login/pt-BR.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "pt-BR",
         "language_name": "Portuguese (Brazil)",
         "language_name_local": "Português (Brasil)",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Selecionar arquivo",
             "PASSWORD_KEY": "Senha",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Descarregar conta demo",
-            "LOGIN_RESULT_KEY": "Resultado do login",
-            "MORE_KEY": "Mais",
-            "CURRENT_URL_KEY": "Url atual",
-            "RELOAD_THE_PAGE_KEY": "Recarregue a página"
+            "RESULT_KEY": "Resultado",
+            "SHOW_MORE_KEY": "Mostre mais",
+            "CURRENT_ADDRESS_KEY": "Endereço atual",
+            "UPDATE_THE_PAGE_KEY": "Atualize a página"
         }
     }
 }

--- a/infohub_login/pt.json
+++ b/infohub_login/pt.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "pt",
         "language_name": "Portuguese",
         "language_name_local": "Português",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Selecionar arquivo",
             "PASSWORD_KEY": "Senha",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Transferir conta demo",
-            "LOGIN_RESULT_KEY": "Resultado do login",
-            "MORE_KEY": "Mais",
-            "CURRENT_URL_KEY": "URL atual",
-            "RELOAD_THE_PAGE_KEY": "Reler a página"
+            "RESULT_KEY": "Resultado",
+            "SHOW_MORE_KEY": "Mostrar mais",
+            "CURRENT_ADDRESS_KEY": "Endereço atual",
+            "UPDATE_THE_PAGE_KEY": "Atualizar a página"
         }
     }
 }

--- a/infohub_login/ro.json
+++ b/infohub_login/ro.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ro",
         "language_name": "Romanian",
         "language_name_local": "Română",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Alegeți fișierul",
             "PASSWORD_KEY": "Parolă",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Descărcaţi contul demo",
-            "LOGIN_RESULT_KEY": "Rezultatul autentificării",
-            "MORE_KEY": "Mai mult",
-            "CURRENT_URL_KEY": "Url curent",
-            "RELOAD_THE_PAGE_KEY": "Reîncarcă pagina"
+            "RESULT_KEY": "Rezultatul",
+            "SHOW_MORE_KEY": "Arată mai mult",
+            "CURRENT_ADDRESS_KEY": "Adresa curentă",
+            "UPDATE_THE_PAGE_KEY": "Actualizează pagina"
         }
     }
 }

--- a/infohub_login/ru.json
+++ b/infohub_login/ru.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ru",
         "language_name": "Russian",
         "language_name_local": "Русский",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Выбрать файл",
             "PASSWORD_KEY": "Пароль",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Скачать демо-счет",
-            "LOGIN_RESULT_KEY": "Результат входа",
-            "MORE_KEY": "Больше",
-            "CURRENT_URL_KEY": "Текущий URL",
-            "RELOAD_THE_PAGE_KEY": "Перезагрузить страницу"
+            "RESULT_KEY": "Результат",
+            "SHOW_MORE_KEY": "Показать больше",
+            "CURRENT_ADDRESS_KEY": "Текущий адрес",
+            "UPDATE_THE_PAGE_KEY": "Обновить страницу"
         }
     }
 }

--- a/infohub_login/sk.json
+++ b/infohub_login/sk.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "sk",
         "language_name": "Slovak",
         "language_name_local": "Slovenský",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Vybrať súbor",
             "PASSWORD_KEY": "Heslo",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Stiahnuť demo účet",
-            "LOGIN_RESULT_KEY": "Výsledok prihlásenia",
-            "MORE_KEY": "Viac",
-            "CURRENT_URL_KEY": "Aktuálna url",
-            "RELOAD_THE_PAGE_KEY": "Znovu načítať stránku"
+            "RESULT_KEY": "Výsledok",
+            "SHOW_MORE_KEY": "Zobraziť viac",
+            "CURRENT_ADDRESS_KEY": "Aktuálna adresa",
+            "UPDATE_THE_PAGE_KEY": "Aktualizovať stránku"
         }
     }
 }

--- a/infohub_login/sl.json
+++ b/infohub_login/sl.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "sl",
         "language_name": "Slovenian",
         "language_name_local": "Slovenski",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Izberite datoteko",
             "PASSWORD_KEY": "Geslo",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Prenesi demo račun",
-            "LOGIN_RESULT_KEY": "Rezultat prijave",
-            "MORE_KEY": "Več",
-            "CURRENT_URL_KEY": "Trenutni url",
-            "RELOAD_THE_PAGE_KEY": "Znova naloži stran"
+            "RESULT_KEY": "Rezultat",
+            "SHOW_MORE_KEY": "Pokaži več",
+            "CURRENT_ADDRESS_KEY": "Trenutni naslov",
+            "UPDATE_THE_PAGE_KEY": "Posodobi stran"
         }
     }
 }

--- a/infohub_login/sq.json
+++ b/infohub_login/sq.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:29:23",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "sq",
         "language_name": "Albanian",
         "language_name_local": "Shqip",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Zgjidh _gjithçka",
             "PASSWORD_KEY": "Fjalëkalimi",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Duke shkarkuar llogarinë",
-            "LOGIN_RESULT_KEY": "Rezultati i hyrjes",
-            "MORE_KEY": "Më shumë",
-            "CURRENT_URL_KEY": "Aktual",
-            "RELOAD_THE_PAGE_KEY": "Rilexo faqen"
+            "RESULT_KEY": "Rezultati",
+            "SHOW_MORE_KEY": "Shfaq më shumë",
+            "CURRENT_ADDRESS_KEY": "Adresa aktuale",
+            "UPDATE_THE_PAGE_KEY": "Rifresko faqen"
         }
     }
 }

--- a/infohub_login/sv.json
+++ b/infohub_login/sv.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "sv",
         "language_name": "Swedish",
         "language_name_local": "Svenska",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Välj fil",
             "PASSWORD_KEY": "Lösenord",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Ladda ner demo-konto",
-            "LOGIN_RESULT_KEY": "Login resultat",
-            "MORE_KEY": "Mer",
-            "CURRENT_URL_KEY": "Nuvarande url",
-            "RELOAD_THE_PAGE_KEY": "Reload sidan"
+            "RESULT_KEY": "Resultat",
+            "SHOW_MORE_KEY": "Visa mer",
+            "CURRENT_ADDRESS_KEY": "Nuvarande adress",
+            "UPDATE_THE_PAGE_KEY": "Uppdatera sidan"
         }
     }
 }

--- a/infohub_login/th.json
+++ b/infohub_login/th.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "th",
         "language_name": "Thai",
         "language_name_local": "ภาษาไทยName",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "เลือกแฟ้ม",
             "PASSWORD_KEY": "รหัสผ่าน",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "ดาวน์โหลดบัญชีผู้ใช้ของสาธิต",
-            "LOGIN_RESULT_KEY": "ผลการล็อกอิน",
-            "MORE_KEY": "เพิ่มเติม",
-            "CURRENT_URL_KEY": "Url ปัจจุบัน",
-            "RELOAD_THE_PAGE_KEY": "เรียกหน้าใหม่อีกครั้ง"
+            "RESULT_KEY": "ผลลัพธ์",
+            "SHOW_MORE_KEY": "แสดงเพิ่มเติม",
+            "CURRENT_ADDRESS_KEY": "ที่อยู่ปัจจุบัน",
+            "UPDATE_THE_PAGE_KEY": "ปรับปรุงหน้า"
         }
     }
 }

--- a/infohub_login/tl.json
+++ b/infohub_login/tl.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "tl",
         "language_name": "Tagalog",
         "language_name_local": "Tagalog",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Pumili ng talaksan",
             "PASSWORD_KEY": "Password",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Download demo account",
-            "LOGIN_RESULT_KEY": "Ang resulta ay Login",
-            "MORE_KEY": "Higit pa",
-            "CURRENT_URL_KEY": "Kasalukuyang url",
-            "RELOAD_THE_PAGE_KEY": "Ikarga muli ang pahina"
+            "RESULT_KEY": "Resulta",
+            "SHOW_MORE_KEY": "Ipakita ang higit pa",
+            "CURRENT_ADDRESS_KEY": "Kasalukuyang direksiyon",
+            "UPDATE_THE_PAGE_KEY": "Itaas ang pahina"
         }
     }
 }

--- a/infohub_login/tr.json
+++ b/infohub_login/tr.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "tr",
         "language_name": "Turkish",
         "language_name_local": "Türk Türkçesi",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Dosyayı seçin",
             "PASSWORD_KEY": "Şifre",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Demo hesabı indirin",
-            "LOGIN_RESULT_KEY": "Sonuç",
-            "MORE_KEY": "Daha fazla",
-            "CURRENT_URL_KEY": "Current url",
-            "RELOAD_THE_PAGE_KEY": "Sayfayı yeniden yükleyin"
+            "RESULT_KEY": "Sonuç",
+            "SHOW_MORE_KEY": "Daha fazlasını göster",
+            "CURRENT_ADDRESS_KEY": "Şimdiki adres",
+            "UPDATE_THE_PAGE_KEY": "Sayfayı güncelleyin"
         }
     }
 }

--- a/infohub_login/uk.json
+++ b/infohub_login/uk.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "uk",
         "language_name": "Ukrainian",
         "language_name_local": "Українська",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "Виберіть файл",
             "PASSWORD_KEY": "Логін",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "Завантажити демо-рахунок",
-            "LOGIN_RESULT_KEY": "Вхід",
-            "MORE_KEY": "Детальніше",
-            "CURRENT_URL_KEY": "Поточний URL",
-            "RELOAD_THE_PAGE_KEY": "Перевантаження сторінки"
+            "RESULT_KEY": "Почати",
+            "SHOW_MORE_KEY": "Показати більше",
+            "CURRENT_ADDRESS_KEY": "Поточна адреса",
+            "UPDATE_THE_PAGE_KEY": "Оновлення сторінки"
         }
     }
 }

--- a/infohub_login/ur.json
+++ b/infohub_login/ur.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:33:41",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "ur",
         "language_name": "Urdu",
         "language_name_local": "اُردو",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "فائل منتخب کریں",
             "PASSWORD_KEY": "پاس ورڈ",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "ڈیم بند کریں",
-            "LOGIN_RESULT_KEY": "لاگ ان نتائج",
-            "MORE_KEY": "مزید",
-            "CURRENT_URL_KEY": "حالیہ پلگ ان",
-            "RELOAD_THE_PAGE_KEY": "صفحہ دوبارہ لوڈ کریں"
+            "RESULT_KEY": "نتیجہ",
+            "SHOW_MORE_KEY": "دکھائیں",
+            "CURRENT_ADDRESS_KEY": "حالیہ پتہ",
+            "UPDATE_THE_PAGE_KEY": "صفحہ کا مطالعہ کريں"
         }
     }
 }

--- a/infohub_login/zh-Hans.json
+++ b/infohub_login/zh-Hans.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:52",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "zh-Hans",
         "language_name": "Chinese",
         "language_name_local": "中国语",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "选择文件",
             "PASSWORD_KEY": "密码",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "下载演示账户",
-            "LOGIN_RESULT_KEY": "登录结果",
-            "MORE_KEY": "更多",
-            "CURRENT_URL_KEY": "当前url",
-            "RELOAD_THE_PAGE_KEY": "重新装入页面"
+            "RESULT_KEY": "结果",
+            "SHOW_MORE_KEY": "显示更多",
+            "CURRENT_ADDRESS_KEY": "当前地址",
+            "UPDATE_THE_PAGE_KEY": "更新页面"
         }
     }
 }

--- a/infohub_login/zh-Hant.json
+++ b/infohub_login/zh-Hant.json
@@ -1,8 +1,8 @@
 {
     "version": {
-        "date": "2025-06-16 20:30:52",
+        "date": "2025-06-18 07:06:41",
         "plugin": "infohub_login",
-        "data_checksum": "91c227617b9f6149647ee785601451b3",
+        "data_checksum": "f3bdf01463f3971dfb292dcf076f4c9c",
         "language": "zh-Hant",
         "language_name": "Chinese (traditional)",
         "language_name_local": "中文( 傳統 )",
@@ -105,10 +105,10 @@
             "SELECT_FILE_KEY": "選擇檔案",
             "PASSWORD_KEY": "密碼",
             "DOWNLOAD_DEMO_ACCOUNT_KEY": "下載演示帳號",
-            "LOGIN_RESULT_KEY": "登入結果",
-            "MORE_KEY": "更多",
-            "CURRENT_URL_KEY": "目前 URL",
-            "RELOAD_THE_PAGE_KEY": "重新載入頁面"
+            "RESULT_KEY": "成果",
+            "SHOW_MORE_KEY": "顯示更多",
+            "CURRENT_ADDRESS_KEY": "目前地址",
+            "UPDATE_THE_PAGE_KEY": "更新頁面"
         }
     }
 }


### PR DESCRIPTION
Improved the english tags in infohub_login so that they were easier to translate for LibreTranslate.
I verified that the Swedish translations are much better now. I hope this change makes the translations much better in other languages too.